### PR TITLE
fixed navbar disappearing upon survey list refresh issue

### DIFF
--- a/frontend/src/layout/layout.jsx
+++ b/frontend/src/layout/layout.jsx
@@ -14,15 +14,17 @@ const Layout = ({ children }) => {
       setCurrentPath(window.location.pathname)
     }
 
+    // Listen for browser back/forward navigation
     window.addEventListener("popstate", handleLocationChange)
-
+    
     return () => {
       window.removeEventListener("popstate", handleLocationChange)
-    }
+          }
   }, [])
 
   useEffect(() => {
-    if (currentPath.startsWith("/survey") || currentPath === '/surveySuccess') {
+    // Check if the path is exactly "/survey" OR exactly "/surveySuccess"
+    if (currentPath === "/survey" || currentPath === '/surveySuccess') { 
       setClientSide(true)
     } else {
       setClientSide(false)


### PR DESCRIPTION
Fixed the issue that upon freshing the Survey List page, the top nav bar disappears. 
Issue fixed by modifying the client side condition - only when path exactly matches /survey or /surveySuccess